### PR TITLE
Minecraft visedretvenost i korutine

### DIFF
--- a/MinecraftSim/Assets/Scenes/VoxelWorld.unity
+++ b/MinecraftSim/Assets/Scenes/VoxelWorld.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18028334, g: 0.22571328, b: 0.3069217, a: 1}
+  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -1039,6 +1039,52 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c88d331728273814c9f14884a57cc36c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &890018425
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 890018427}
+  - component: {fileID: 890018426}
+  m_Layer: 0
+  m_Name: WorldRender
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &890018426
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 890018425}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 669df5c12178977419deff727d8cf5bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  chunkPrefab: {fileID: 7915555101801397518, guid: 3d2ee060692129a4f8bdcfbc134ec151,
+    type: 3}
+--- !u!4 &890018427
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 890018425}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -84.11855, y: -19.143269, z: -80.93102}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &900010580 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1893066722943186898, guid: 511d644c7c5c53d4e82b1ad652553858,
@@ -1474,9 +1520,10 @@ MonoBehaviour:
   mapSizeInChunks: 10
   chunkSize: 16
   chunkHeight: 100
-  chunkDrawingRangen: 2
+  chunkDrawingRange: 8
   chunkPrefab: {fileID: 7915555101801397518, guid: 3d2ee060692129a4f8bdcfbc134ec151,
     type: 3}
+  worldRenderer: {fileID: 890018426}
   terrainGenerator: {fileID: 1588338199}
   mapSeedOffset: {x: 0, y: 0}
   OnWorldCreated:
@@ -3311,3 +3358,4 @@ SceneRoots:
   - {fileID: 1588338200}
   - {fileID: 1573277603}
   - {fileID: 1458565793}
+  - {fileID: 890018427}

--- a/MinecraftSim/Assets/_Scripts/World.cs
+++ b/MinecraftSim/Assets/_Scripts/World.cs
@@ -21,6 +21,9 @@ public class World : MonoBehaviour
 
     // Prefab korišten za instanciranje chunkova
     public GameObject chunkPrefab;
+
+    // worldRenderer varijabla služi za ponovno iskorištenje starih iskorištenih chunkova
+    public WorldRenderer worldRenderer;
     public TerrainGenerator terrainGenerator;
 
     // Offset mape, korišten za proceduralnu generaciju
@@ -188,13 +191,10 @@ public class World : MonoBehaviour
 
     private void CreateChunk(WorldData worldData, Vector3Int position, MeshData meshData)
     {
-        // U ovoj metodi se renderira pojedini MeshData (odnosno chunk)
+        // U ovoj metodi se poziva worldRenderer.RenderChunk koji renderira pojedini MeshData. U rječnik se dodaje chunkRenderer koji je vraćen iz spomenute metode na odgovarajuću poziciju
 
-        GameObject chunkObject = Instantiate(chunkPrefab, position, Quaternion.identity);
-        ChunkRenderer chunkRenderer = chunkObject.GetComponent<ChunkRenderer>();
+        ChunkRenderer chunkRenderer = worldRenderer.RenderChunk(worldData, position, meshData);
         worldData.chunkDictionary.Add(position, chunkRenderer);
-        chunkRenderer.InitializeChunk(worldData.chunkDataDictionary[position]);
-        chunkRenderer.UpdateChunk(meshData);
     }
 
     private WorldGenerationData GetPositionsThatPlayerSees(Vector3Int playerPosition)
@@ -256,11 +256,6 @@ public class World : MonoBehaviour
         OnNewChunksGenerated?.Invoke();
     }
 
-    internal void RemoveChunk(ChunkRenderer chunk)
-    {
-        chunk.gameObject.SetActive(false);
-    }
-
     public void OnDisable()
     {
         // Ova metoda se poziva kada se zaustavi editor (zajedno sa metodom OnDestroy())
@@ -276,12 +271,12 @@ public class World : MonoBehaviour
         public List<Vector3Int> chunkPositionsToRemove;
         public List<Vector3Int> chunkDataToRemove;
     }
+}
 
-    public struct WorldData
-    {
-        public Dictionary<Vector3Int, ChunkData> chunkDataDictionary;
-        public Dictionary<Vector3Int, ChunkRenderer> chunkDictionary;
-        public int chunkSize;
-        public int chunkHeight;
-    }
+public struct WorldData
+{
+    public Dictionary<Vector3Int, ChunkData> chunkDataDictionary;
+    public Dictionary<Vector3Int, ChunkRenderer> chunkDictionary;
+    public int chunkSize;
+    public int chunkHeight;
 }

--- a/MinecraftSim/Assets/_Scripts/WorldDataHelper.cs
+++ b/MinecraftSim/Assets/_Scripts/WorldDataHelper.cs
@@ -86,7 +86,7 @@ public static class WorldDataHelper
         return chunkDataPositionsToCreate;
     }
 
-    internal static List<Vector3Int> GetUnneededChunks(World.WorldData worldData, List<Vector3Int> allChunkPositionsNeeded)
+    internal static List<Vector3Int> GetUnneededChunks(WorldData worldData, List<Vector3Int> allChunkPositionsNeeded)
     {
         // Ova metoda pronalazi i vraća pozicije chunkova koje više nisu potrebne.
 
@@ -102,7 +102,7 @@ public static class WorldDataHelper
         return positionToRemove;
     }
 
-    internal static List<Vector3Int> GetUnneededData(World.WorldData worldData, List<Vector3Int> allChunkDataPositionsNeeded)
+    internal static List<Vector3Int> GetUnneededData(WorldData worldData, List<Vector3Int> allChunkDataPositionsNeeded)
     {
         // Ova metoda pronalazi i vraća pozicije podataka chunkova koje više nisu potrebne.
 
@@ -118,7 +118,7 @@ public static class WorldDataHelper
         ChunkRenderer chunk = null;
         if (world.worldData.chunkDictionary.TryGetValue(pos, out chunk))
         {
-            world.RemoveChunk(chunk);
+            world.worldRenderer.RemoveChunk(chunk);
             world.worldData.chunkDictionary.Remove(pos);
         }
     }
@@ -130,14 +130,14 @@ public static class WorldDataHelper
         world.worldData.chunkDataDictionary.Remove(pos);
     }
 
-    internal static List<Vector3Int> SelectDataPositionsToCreate(World.WorldData worldData, List<Vector3Int> allChunkDataPositionsNeeded, Vector3Int playerPosition)
+    internal static List<Vector3Int> SelectDataPositionsToCreate(WorldData worldData, List<Vector3Int> allChunkDataPositionsNeeded, Vector3Int playerPosition)
     {
         // Ova metoda bira podatke chunkova koji se trebaju stvoriti s obzirom na blizinu igrača. Sortira ih, te vraća listu tih podataka.
 
         return allChunkDataPositionsNeeded.Where(pos => worldData.chunkDataDictionary.ContainsKey(pos) == false).OrderBy(pos => Vector3.Distance(playerPosition, pos)).ToList();
     }
 
-    internal static List<Vector3Int> SelectPositionsToCreate(World.WorldData worldData, List<Vector3Int> allChunkPositionsNeeded, Vector3Int playerPosition)
+    internal static List<Vector3Int> SelectPositionsToCreate(WorldData worldData, List<Vector3Int> allChunkPositionsNeeded, Vector3Int playerPosition)
     {
         // Ova metoda bira chunkove koji se trebaju stvoriti s obzirom na blizinu igrača. Sortira ih, te vraća listu tih podataka.
 

--- a/MinecraftSim/Assets/_Scripts/WorldRenderer.cs
+++ b/MinecraftSim/Assets/_Scripts/WorldRenderer.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class WorldRenderer : MonoBehaviour
+{
+    // Ova klasa je implementirana za ponovno iskorištenje starih isključenih chunkova u nove chunkove (nove pozicije)
+
+    public GameObject chunkPrefab;
+
+    // Isključeni chunk postavlja se u chunkPool, te prilikom "kreacije" novog chunka, uzima se chunk iz chunkPool-a, uključuje se te kreira pomoću novog MeshData
+    public Queue<ChunkRenderer> chunkPool = new Queue<ChunkRenderer>();
+
+    public void Clear(WorldData worldData)
+    {
+        // Ova metoda omogućuje čišćenje svijeta (chunk objekata koji su vidljivi)
+
+        foreach (var item in worldData.chunkDictionary.Values)
+        {
+            Destroy(item.gameObject);
+        }
+        chunkPool.Clear();
+    }
+    internal ChunkRenderer RenderChunk(WorldData worldData, Vector3Int position, MeshData meshData)
+    {
+        // U ovoj metodi se renderira pojedini MeshData (odnosno chunk)
+
+        ChunkRenderer newChunk = null;
+        if (chunkPool.Count > 0)
+        {
+            newChunk = chunkPool.Dequeue();
+            newChunk.transform.position = position;
+        }
+        else
+        {
+            GameObject chunkObject = Instantiate(chunkPrefab, position, Quaternion.identity);
+            newChunk = chunkObject.GetComponent<ChunkRenderer>();
+        }
+
+        newChunk.InitializeChunk(worldData.chunkDataDictionary[position]);
+        newChunk.UpdateChunk(meshData);
+        newChunk.gameObject.SetActive(true);
+        return newChunk;
+    }
+
+    public void RemoveChunk(ChunkRenderer chunk)
+    {
+        // Metoda koja isključuje chunk (ChunkRenderer) te ga postavlja u chunkPool kako bi se mogao ponovno iskoristiti za neku drugu poziciju u svijetu
+
+        chunk.gameObject.SetActive(false);
+        chunkPool.Enqueue(chunk);
+    }
+}

--- a/MinecraftSim/Assets/_Scripts/WorldRenderer.cs.meta
+++ b/MinecraftSim/Assets/_Scripts/WorldRenderer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 669df5c12178977419deff727d8cf5bd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Omogućeno je:

- Renderiranje **1 chunka** po **1 frame-u**.
- Kalkulacije vezane uz chunkove i mesheve se **izvršavaju u zasebnim dretvama** kako bi se oslobodila glavna dretva. Ovo se ostvarilo pomoću **asinkronog programiranja** i **taskova**.
- Prilikom zaustavljanja igre, **zaustavljaju se i pokrenuti taskovi**. Kao pripomoć služi **Token** koji se šalje kao drugi parametar taskovima.
- Chunkovi (ChunkRendereri) koji su isključeni se smještaju u red, te prilikom potrebe za novim chunkovima na novim pozicijama, **prvo se provjerava postoje li ChunkRendereri u redu** (**koji se mogu ponovno iskoristiti** za novu poziciju i novi MeshData).