### PR TITLE
Dodana drveća u svijetu. Closes #93

### DIFF
--- a/MinecraftSim/Assets/Scenes/VoxelWorld.unity
+++ b/MinecraftSim/Assets/Scenes/VoxelWorld.unity
@@ -408,6 +408,52 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c88d331728273814c9f14884a57cc36c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &319068462
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 319068463}
+  - component: {fileID: 319068464}
+  m_Layer: 0
+  m_Name: TreeLayer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &319068463
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 319068462}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 344019990}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &319068464
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 319068462}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e4981de9c21f2354493bba2f83cb2994, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Next: {fileID: 0}
+  terrainHeightLimit: 25
 --- !u!1 &330585543
 GameObject:
   m_ObjectHideFlags: 0
@@ -591,6 +637,7 @@ GameObject:
   - component: {fileID: 344019990}
   - component: {fileID: 344019989}
   - component: {fileID: 344019991}
+  - component: {fileID: 344019992}
   m_Layer: 0
   m_Name: BiomeGenerator
   m_TagString: Untagged
@@ -617,6 +664,8 @@ MonoBehaviour:
   startLayerHandler: {fileID: 537980144}
   additionalLayerHandlers:
   - {fileID: 79675633}
+  - {fileID: 319068464}
+  treeGenerator: {fileID: 344019992}
 --- !u!4 &344019990
 Transform:
   m_ObjectHideFlags: 0
@@ -635,6 +684,7 @@ Transform:
   - {fileID: 1455838299}
   - {fileID: 1024238322}
   - {fileID: 154981728}
+  - {fileID: 319068463}
   m_Father: {fileID: 1588338200}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &344019991
@@ -653,6 +703,20 @@ MonoBehaviour:
   noiseDomainY: {fileID: 11400000, guid: 2e7c0809104a12c44ada4b3f755e6a1c, type: 2}
   amplitudeX: 80
   amplitudeY: 80
+--- !u!114 &344019992
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 344019988}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a4e06f8b1aaef524586ad9cafb03f7aa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  treeNoiseSettings: {fileID: 11400000, guid: adbde2b0ac9187d4b88b22da67771538, type: 2}
+  domainWarping: {fileID: 344019991}
 --- !u!1 &383376300
 GameObject:
   m_ObjectHideFlags: 3

--- a/MinecraftSim/Assets/_Scripts/BiomeGenerator.cs
+++ b/MinecraftSim/Assets/_Scripts/BiomeGenerator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -20,6 +21,9 @@ public class BiomeGenerator : MonoBehaviour
     // Handleri dodatnih blokova
     public List<BlockLayerHandler> additionalLayerHandlers;
 
+    // Ukoliko se ne želi postavljati stabla u određenom biomu, treeGenerator se postavlja na null vrijednost
+    public TreeGenerator treeGenerator;
+
     public ChunkData ProcessChunkColumn(ChunkData data, int x, int z, Vector2Int mapSeedOffset)
     {
         // Ova metoda prerađuje stupac u chunku zadajući tip bloka za svaki blok unutar chunka baziranim na visini terena.
@@ -32,7 +36,7 @@ public class BiomeGenerator : MonoBehaviour
         // Pomoću sustava "Chain Of Responsibility" odlučuje se na temelju visine koji tip bloka postaviti
         for (int y = 0; y < data.chunkHeight; y++)
         {
-        startLayerHandler.Handle(data, x, y, z, groundPosition, mapSeedOffset);
+            startLayerHandler.Handle(data, x, y, z, groundPosition, mapSeedOffset);
         }
 
         // Postavljanje dodatnih tipa blokova (npr. "kamen")
@@ -41,6 +45,12 @@ public class BiomeGenerator : MonoBehaviour
             layer.Handle(data, x, data.worldPosition.y, z, groundPosition, mapSeedOffset);
         }
         return data;
+    }
+
+    internal TreeData GetTreeData(ChunkData data, Vector2Int mapSeedOffset)
+    {
+        if (treeGenerator == null) return new TreeData();
+        return treeGenerator.GenerateTreeData(data, mapSeedOffset);
     }
 
     private int GetSurfaceHeightNoise(int x, int z, int chunkHeight)

--- a/MinecraftSim/Assets/_Scripts/Chunk.cs
+++ b/MinecraftSim/Assets/_Scripts/Chunk.cs
@@ -73,7 +73,8 @@ public static class Chunk
         }
         else
         {
-            throw new Exception("Need to ask the World for appropriate chunk");
+            // Ukoliko pozicija nije u chunku, provjerava se u svijetu
+            WorldDataHelper.SetBlock(chunkData.worldReference, localPosition + chunkData.worldPosition, block);
         }
     }
 

--- a/MinecraftSim/Assets/_Scripts/ChunkData.cs
+++ b/MinecraftSim/Assets/_Scripts/ChunkData.cs
@@ -21,6 +21,9 @@ public class ChunkData
     // U proceduralno generiranom svijetu, lako se mogu regenerirati chunkovi, međutim u slučaju da igrač napravi izmjene na chunku, spremamo podatke o chunkovima koji su izmijenjeni
     public bool modifiedByThePlayer = false;
 
+    // Podaci o stablima unutar chunka
+    public TreeData treeData;
+
     public ChunkData(int chunkSize, int chunkHeight, World world, Vector3Int worldPosition) {
         this.chunkHeight = chunkHeight;
         this.chunkSize = chunkSize;

--- a/MinecraftSim/Assets/_Scripts/TerrainGenerator.cs
+++ b/MinecraftSim/Assets/_Scripts/TerrainGenerator.cs
@@ -6,11 +6,18 @@ public class TerrainGenerator : MonoBehaviour
     public BiomeGenerator biomeGenerator;
     public ChunkData GenerateChunkData(ChunkData data, Vector2Int mapSeedOffset)
     {
+        // Linije koda koje se tiču treeData su postavljene prije 2 for petlje iz razloga jer se želi jednom izračunati vrijednosti šuma.
+
+        // Generiraju se podaci o stablima, razliku može činiti sam mapSeedOffset.
+        TreeData treeData = biomeGenerator.GetTreeData(data, mapSeedOffset);
+        // Podaci o stablima se spremaju u ChunkData. Razlog tome je da prilikom renderiranja chunkova, treba uključiti samo lišće koje je vidljivo u odgovarajućem chunku.
+        data.treeData = treeData;
+
         for (int x = 0; x < data.chunkSize; x++)
         {
             for (int z = 0; z < data.chunkSize; z++)
             {
-                // Za svaku poziciju potrebno je terenske podatke
+                // Za svaku poziciju potrebno je generirati terenske podatke
                 data = biomeGenerator.ProcessChunkColumn(data, x, z, mapSeedOffset);
             }
         }

--- a/MinecraftSim/Assets/_Scripts/Trees.meta
+++ b/MinecraftSim/Assets/_Scripts/Trees.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f11f30bbdca39014bbc65926d60e65d6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/MinecraftSim/Assets/_Scripts/Trees/DataProcessing.cs
+++ b/MinecraftSim/Assets/_Scripts/Trees/DataProcessing.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+public static class DataProcessing
+{
+    // Klasa DataProcessing sadrži metode koje pronalaze pozicije stabala unutar proslijeđenih chunkova
+
+    // directions varijabla služi za dobivanje pozicije susjeda
+    public static List<Vector2Int> directions = new List<Vector2Int>
+    {
+        new Vector2Int( 0, 1 ),   // N
+        new Vector2Int( 1, 1 ),   // NE
+        new Vector2Int( 1, 0 ),   // E
+        new Vector2Int( -1, 1 ),  // SE
+        new Vector2Int( -1, 0 ),  // S
+        new Vector2Int( -1, -1 ), // SW
+        new Vector2Int( 0, -1 ),  // W
+        new Vector2Int( 1, -1 )   // NW
+    };
+
+    public static List<Vector2Int> FindLocalMaxima(float[,] dataMatrix, int xCoord, int zCoord)
+    {
+        // Metoda FindLocalMaxima nalazi lokalne ekstreme unutar 2D polja dataMatrix i vraća Listu pozicija gdje se nalaze stabla
+
+        // Lista maximas sadrži svjetske pozicije stabala
+        List<Vector2Int> maximas = new List<Vector2Int>();
+
+        for (int x = 0; x < dataMatrix.GetLength(0); x++)
+        {
+            for (int y = 0; y < dataMatrix.GetLength(1); y++)
+            {
+                float noiseVal = dataMatrix[x, y];
+                if (CheckNeighbours(dataMatrix, x, y, (neighbourNoise) => neighbourNoise < noiseVal))
+                {
+                    maximas.Add(new Vector2Int(xCoord + x, zCoord + y));
+                }
+            }
+        }
+        return maximas;
+    }
+
+    private static bool CheckNeighbours(float[,] dataMatrix, int x, int y, Func<float, bool> successCondition)
+    {
+        /*
+            Metoda CheckNeighbours provjerava za pojedinu vrijednost šuma, da li je ona lokalni ekstrem. Lokalni je ekstrem ukoliko ni jedan od susjeda nema veću vrijednost.
+            Parametar dataMatrix označava generiranu vrijednost šuma za svaku poziciciju unutar chunka, x i z su svjetske koordinate chunka. Funkcija successCondition
+            predstavlja uvjet koji mora vrijediti za svakog od susjeda kako bi promatrana pozicija bila lokalni maksimum.
+        */
+
+
+        foreach (var dir in directions)
+        {
+
+            // Pozicija susjeda
+            var newPos = new Vector2Int(x + dir.x, y + dir.y);
+
+            // Provjera nalazi li se pozicija u željenom rasponu unutar chunka
+            if (newPos.x < 0 || newPos.x >= dataMatrix.GetLength(0) || newPos.y < 0 || newPos.y >= dataMatrix.GetLength(1))
+            {
+                continue;
+            }
+
+            // Ukoliko je vrijednost lokalnog maksimuma jednog od susjeda veća od vrijednosti lokalnog maksimuma trenutne pozicije, na trenutnoj poziciji neće biti postavljeno drveće
+            if (successCondition(dataMatrix[x + dir.x, y + dir.y]) == false)
+            {
+                return false;
+            }
+        }
+
+        // Pronađen je lokalni maksimum
+        return true;
+    }
+}

--- a/MinecraftSim/Assets/_Scripts/Trees/DataProcessing.cs
+++ b/MinecraftSim/Assets/_Scripts/Trees/DataProcessing.cs
@@ -26,9 +26,10 @@ public static class DataProcessing
         // Lista maximas sadrži svjetske pozicije stabala
         List<Vector2Int> maximas = new List<Vector2Int>();
 
-        for (int x = 0; x < dataMatrix.GetLength(0); x++)
+        // Kreće se od 2 kako bi se popravila greška lijepljenja drveća susjednih chunkova, izbjegava se generiranje drveća uz rub chunka
+        for (int x = 2; x < dataMatrix.GetLength(0); x++)
         {
-            for (int y = 0; y < dataMatrix.GetLength(1); y++)
+            for (int y = 2; y < dataMatrix.GetLength(1); y++)
             {
                 float noiseVal = dataMatrix[x, y];
                 if (CheckNeighbours(dataMatrix, x, y, (neighbourNoise) => neighbourNoise < noiseVal))

--- a/MinecraftSim/Assets/_Scripts/Trees/DataProcessing.cs.meta
+++ b/MinecraftSim/Assets/_Scripts/Trees/DataProcessing.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2a4eaf10310abeb428f762581f587b44
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/MinecraftSim/Assets/_Scripts/Trees/TreeData.cs
+++ b/MinecraftSim/Assets/_Scripts/Trees/TreeData.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class TreeData
+{
+    // treePositions su neovisni o y komponenti (visini), generiraju se odabirom slučajne pozicije pomoću Perlinovog šuma.
+    public List<Vector2Int> treePositions = new List<Vector2Int>();
+    // treeLeafesSolid je indikator gdje postaviti voxel koji predstavlja lišće drveća
+    public List<Vector3Int> treeLeafesSolid = new List<Vector3Int>();
+}

--- a/MinecraftSim/Assets/_Scripts/Trees/TreeData.cs.meta
+++ b/MinecraftSim/Assets/_Scripts/Trees/TreeData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2633ba2de927e7840a6d690e7dbda3bc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/MinecraftSim/Assets/_Scripts/Trees/TreeGenerator.cs
+++ b/MinecraftSim/Assets/_Scripts/Trees/TreeGenerator.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class TreeGenerator : MonoBehaviour
+{
+    // Klasa TreeGenerator je odgovorna za generiranje podataka drveća za pojedini chunk u svijetu. Koristi postavke šuma i Domain Warping kako bi se odlučile pozicije drveća.
+    
+    public NoiseSettings treeNoiseSettings;
+    public DomainWarping domainWarping;
+
+    public TreeData GenerateTreeData(ChunkData chunkData, Vector2Int mapSeedOffset)
+    {
+        /* 
+            Metoda GenerateTreeData poziva funkciju GenerateTreeNoise kako bi se izračunala vrijednost šuma za svaku poziciju unutar chunka, a potom
+            poziva FindLocalMaxima koja izračunava pozicije drveća za odgovarajući chunk
+        */
+
+        treeNoiseSettings.worldOffset = mapSeedOffset;
+        TreeData treeData = new TreeData();
+        float[,] noiseData = GenerateTreeNoise(chunkData, treeNoiseSettings);
+        treeData.treePositions = DataProcessing.FindLocalMaxima(noiseData, chunkData.worldPosition.x, chunkData.worldPosition.z);
+        return treeData;
+    }
+
+    private float[,] GenerateTreeNoise(ChunkData chunkData, NoiseSettings treeNoiseSettings)
+    {
+        // GenerateTreeNoise metoda stvara 2D polje vrijednosti šuma za odgovarajući chunk (za svaku poziciju u chunku se izračunava vrijednost šuma)
+
+        // 2D polje float vrijednosti šuma
+        float[,] noiseMax = new float[chunkData.chunkSize, chunkData.chunkSize];
+
+        // Ove 4 vrijednosti su točke koje definiraju "granični okvir" chunka
+        int xMax = chunkData.worldPosition.x + chunkData.chunkSize;
+        int xMin = chunkData.worldPosition.x;
+        int zMax = chunkData.worldPosition.z + chunkData.chunkSize;
+        int zMin = chunkData.worldPosition.z;
+
+        // S obzirom da su x i z vrijednost unutar dvostruke for petlje koordinate u prostoru svijeta, potrebni su xIndex i zIndex kako bi se vrijednosti korektno mapirale u noiseMax polje.
+        int xIndex = 0, zIndex = 0;
+        for (int x = xMin; x < xMax; x++) 
+        {
+            for (int z = zMin; z < zMax; z++)
+            {
+                noiseMax[xIndex, zIndex] = domainWarping.GenerateDomainNoise(x, z, treeNoiseSettings);
+                zIndex++;
+            }
+            xIndex++;
+            zIndex = 0;
+        }
+        return noiseMax;
+    }
+}

--- a/MinecraftSim/Assets/_Scripts/Trees/TreeGenerator.cs
+++ b/MinecraftSim/Assets/_Scripts/Trees/TreeGenerator.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using Unity.Mathematics;
 using UnityEngine;
 
 public class TreeGenerator : MonoBehaviour
@@ -43,7 +44,15 @@ public class TreeGenerator : MonoBehaviour
         {
             for (int z = zMin; z < zMax; z++)
             {
-                noiseMax[xIndex, zIndex] = domainWarping.GenerateDomainNoise(x, z, treeNoiseSettings);
+                // Vrijednosti uz rub chunka gdje se neće generirati drveća postavljaju se na minimalnu vrijednost kako bi se kompenzirao broj stvorenih drveća
+                if (z <= zMin + 1 || z >= zMax - 2 || x <= xMin + 1 || x >= xMax - 2) 
+                {
+                    noiseMax[xIndex, zIndex] = 0;
+                } 
+                else 
+                {
+                    noiseMax[xIndex, zIndex] = domainWarping.GenerateDomainNoise(x, z, treeNoiseSettings);
+                }
                 zIndex++;
             }
             xIndex++;

--- a/MinecraftSim/Assets/_Scripts/Trees/TreeGenerator.cs.meta
+++ b/MinecraftSim/Assets/_Scripts/Trees/TreeGenerator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a4e06f8b1aaef524586ad9cafb03f7aa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/MinecraftSim/Assets/_Scripts/Trees/TreeLayerHandler.cs
+++ b/MinecraftSim/Assets/_Scripts/Trees/TreeLayerHandler.cs
@@ -1,0 +1,83 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class TreeLayerHandler : BlockLayerHandler
+{
+    // Klasa TreeLayerHandler provjerava može li se na određenoj poziciji u chunku postaviti stablo, te ukoliko može, postavlja ga
+
+    // Visina iznad koje se ne postavljaju drveća
+    public float terrainHeightLimit = 25;
+
+    // Lista pozicija lišća drveća
+    public static List<Vector3Int> treeLeafesStaticLayout = new List<Vector3Int>
+    {
+        new Vector3Int(-2, 0, -2),
+        new Vector3Int(-2, 0, -1),
+        new Vector3Int(-2, 0, 0),
+        new Vector3Int(-2, 0, 1),
+        new Vector3Int(-2, 0, 2),
+        new Vector3Int(-1, 0, -2),
+        new Vector3Int(-1, 0, -1),
+        new Vector3Int(-1, 0, 0),
+        new Vector3Int(-1, 0, 1),
+        new Vector3Int(-1, 0, 2),
+        new Vector3Int(0, 0, -2),
+        new Vector3Int(0, 0, -1),
+        new Vector3Int(0, 0, 0),
+        new Vector3Int(0, 0, 1),
+        new Vector3Int(0, 0, 2),
+        new Vector3Int(1, 0, -2),
+        new Vector3Int(1, 0, -1),
+        new Vector3Int(1, 0, 0),
+        new Vector3Int(1, 0, 1),
+        new Vector3Int(1, 0, 2),
+        new Vector3Int(2, 0, -2),
+        new Vector3Int(2, 0, -1),
+        new Vector3Int(2, 0, 0),
+        new Vector3Int(2, 0, 1),
+        new Vector3Int(2, 0, 2),
+        new Vector3Int(-1, 1, -1),
+        new Vector3Int(-1, 1, 0),
+        new Vector3Int(-1, 1, 1),
+        new Vector3Int(0, 1, -1),
+        new Vector3Int(0, 1, 0),
+        new Vector3Int(0, 1, 1),
+        new Vector3Int(1, 1, -1),
+        new Vector3Int(1, 1, 0),
+        new Vector3Int(1, 1, 1),
+        new Vector3Int(0, 2, 0)
+    };
+
+    protected override bool TryHandling(ChunkData chunkData, int x, int y, int z, int surfaceHeightNoise, Vector2Int mapSeedOffset)
+    {
+        // Ispod površine se neće postavljati drveća
+        if (chunkData.worldPosition.y < 0) return false;
+
+        if (surfaceHeightNoise < terrainHeightLimit && chunkData.treeData.treePositions.Contains(new Vector2Int(chunkData.worldPosition.x + x, chunkData.worldPosition.z + z)))
+        {
+            // Provjera koji je tip bloka ispod stabla (postavlja se stablo samo ako je Grass_Dirt)
+            Vector3Int chunkCoordinates = new Vector3Int(x, surfaceHeightNoise, z);
+            BlockType type = Chunk.GetBlockFromChunkCoordinates(chunkData, chunkCoordinates);
+
+            if (type == BlockType.Grass_Dirt)
+            {
+                // Ispod tla postavljamo Dirt
+                Chunk.SetBlock(chunkData, chunkCoordinates, BlockType.Dirt);
+                for (int i = 1; i < 5; i++)
+                {
+                    // Postavlja se stablo
+                    chunkCoordinates.y = surfaceHeightNoise + i;
+                    Chunk.SetBlock(chunkData, chunkCoordinates, BlockType.TreeTrunk);
+                }
+
+                foreach (Vector3Int leafPosition in treeLeafesStaticLayout)
+                {
+                    // Postavljaju se lišća za pojedino stablo
+                    chunkData.treeData.treeLeafesSolid.Add(new Vector3Int(x + leafPosition.x, surfaceHeightNoise + 5 + leafPosition.y, z + leafPosition.z));
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/MinecraftSim/Assets/_Scripts/Trees/TreeLayerHandler.cs.meta
+++ b/MinecraftSim/Assets/_Scripts/Trees/TreeLayerHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e4981de9c21f2354493bba2f83cb2994
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/MinecraftSim/Assets/_Scripts/World.cs
+++ b/MinecraftSim/Assets/_Scripts/World.cs
@@ -98,6 +98,12 @@ public class World : MonoBehaviour
             worldData.chunkDataDictionary.Add(calculatedData.Key, calculatedData.Value);
         }
 
+        // Nakon generacije svih potrebnih chunkova, mogu se dodati lišća. Ovo se radi kako ne bi pristupili chunku koji se još uvijek procesira na zasebnoj dretvi
+        foreach (var chunkData in worldData.chunkDataDictionary.Values)
+        {
+            AddTreeLeafs(chunkData);
+        }
+
         ConcurrentDictionary<Vector3Int, MeshData> meshDataDictionary = new ConcurrentDictionary<Vector3Int, MeshData>();
 
         // Izabiru se samo key-value parovi koji se nalaze u chunkPositionsToCreate (gleda se po poziciji), od njih se izabire vrijednost ChunkData i pretvaraju se u listu
@@ -117,6 +123,15 @@ public class World : MonoBehaviour
         }
 
         StartCoroutine(ChunkCreationCoroutine(meshDataDictionary));
+    }
+
+    private void AddTreeLeafs(ChunkData chunkData)
+    {
+        // Za sve pozicije lišća, postavlja se blok lišća
+        foreach (var treeLeafes in chunkData.treeData.treeLeafesSolid)
+        {
+            Chunk.SetBlock(chunkData, treeLeafes, BlockType.TreeLeafsSolid);
+        }
     }
 
     private Task<ConcurrentDictionary<Vector3Int, MeshData>> CreateMeshDataAsync(List<ChunkData> dataToRender)

--- a/MinecraftSim/Assets/_Scripts/WorldDataHelper.cs
+++ b/MinecraftSim/Assets/_Scripts/WorldDataHelper.cs
@@ -6,15 +6,15 @@ public static class WorldDataHelper
 {
     // Ova klasa pruža korisne metode za upravljanje podacima svijeta i pozicijama chunkova
 
-    public static Vector3Int ChunkPositionFromBlockCoords(World world, Vector3Int position)
+    public static Vector3Int ChunkPositionFromBlockCoords(World world, Vector3Int worldPosition)
     {
         // Ova metoda vraća početne world koordinate chunka
 
         return new Vector3Int
         {
-            x = Mathf.FloorToInt(position.x / (float)world.chunkSize) * world.chunkSize,
-            y = Mathf.FloorToInt(position.y / (float)world.chunkHeight) * world.chunkHeight,
-            z = Mathf.FloorToInt(position.z / (float)world.chunkSize) * world.chunkSize
+            x = Mathf.FloorToInt(worldPosition.x / (float)world.chunkSize) * world.chunkSize,
+            y = Mathf.FloorToInt(worldPosition.y / (float)world.chunkHeight) * world.chunkHeight,
+            z = Mathf.FloorToInt(worldPosition.z / (float)world.chunkSize) * world.chunkSize
         };
     }
 
@@ -142,5 +142,27 @@ public static class WorldDataHelper
         // Ova metoda bira chunkove koji se trebaju stvoriti s obzirom na blizinu igrača. Sortira ih, te vraća listu tih podataka.
 
         return allChunkPositionsNeeded.Where(pos => worldData.chunkDictionary.ContainsKey(pos) == false).OrderBy(pos => Vector3.Distance(playerPosition, pos)).ToList();
+    }
+
+    public static ChunkData GetChunkData(World worldReference, Vector3Int worldBlockPosition)
+    {
+        // U metodi GetChunkData pokušava se dohvatiti chunk koji sadrži blok sa definiranom pozicijom u svijetu
+
+        Vector3Int chunkPosition = ChunkPositionFromBlockCoords(worldReference, worldBlockPosition);
+        ChunkData containerChunk = null;
+        worldReference.worldData.chunkDataDictionary.TryGetValue(chunkPosition, out containerChunk);
+        return containerChunk;
+    }
+
+    internal static void SetBlock(World worldReference, Vector3Int worldBlockPosition, BlockType blockType)
+    {
+        // U ovoj metodi pokušava se postaviti tip bloka na blok sa poznatom pozicijom u svijetu
+
+        ChunkData chunkData = GetChunkData(worldReference, worldBlockPosition);
+        if (chunkData != null)
+        {
+            Vector3Int localPosition = Chunk.GetBlockInChunkCoordinates(chunkData, worldBlockPosition);
+            Chunk.SetBlock(chunkData, localPosition, blockType);
+        }
     }
 }

--- a/MinecraftSim/Assets/_Scripts/treeNoiseSettings.asset
+++ b/MinecraftSim/Assets/_Scripts/treeNoiseSettings.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 684637bdef049f0438200bf7f854375b, type: 3}
+  m_Name: treeNoiseSettings
+  m_EditorClassIdentifier: 
+  noiseZoom: 0.02
+  octaves: 1
+  offset: {x: 300, y: 5000}
+  worldOffset: {x: 0, y: 0}
+  persistance: 0.01
+  redistributionModifier: 1.2
+  exponent: 4

--- a/MinecraftSim/Assets/_Scripts/treeNoiseSettings.asset.meta
+++ b/MinecraftSim/Assets/_Scripts/treeNoiseSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: adbde2b0ac9187d4b88b22da67771538
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- Implementirana su drveća koja se postavljaju u svijet na temelju toga **jesu li njihove pozicije lokalni maksimum** unutar samog chunka (na temelju vrijednosti šuma pridodijeljenoj svakoj poziciji unutar chunka). 
- Drveća se postavljaju samo ukoliko je podloga **Grass_Dirt** kako bi se izbjegli **pogrešni tipovi blokova** poput **kamena**. 
- Postoji **bug** u kojem se dva drveća **generiraju veoma blizu jedan drugome**, te će se to morati u budućnosti riješiti.